### PR TITLE
[fixed a bug] added support for rails 3.0.12 with the new html_safe changes

### DIFF
--- a/lib/localized_country_select.rb
+++ b/lib/localized_country_select.rb
@@ -99,7 +99,7 @@ module ActionView
         value = value(object)
         content_tag("select",
           add_options(
-            localized_country_options_for_select(value, priority_countries, options),
+            localized_country_options_for_select(value, priority_countries, options).html_safe,
             options, value
           ), html_options
         )


### PR DESCRIPTION
The fix is only a few characters. I noticed this afternoon after upgrading rails that my drop down options were all html encoded. I would write a test, but since this gem supports rails 2.3... I didn't want to update the rails version in order to reproduce it issue.

If you would like me to do more let me know. I just want my country drop down :)

Cheers!
