### PR TITLE
Remove duplicate rails dependencies

### DIFF
--- a/localized_country_select.gemspec
+++ b/localized_country_select.gemspec
@@ -57,14 +57,12 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
-      s.add_runtime_dependency(%q<rails>, [">= 2.3.5"])
     else
       s.add_dependency(%q<rails>, [">= 2.3.5"])
       s.add_dependency(%q<rspec>, [">= 2.3.0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_dependency(%q<rcov>, [">= 0"])
-      s.add_dependency(%q<rails>, [">= 2.3.5"])
     end
   else
     s.add_dependency(%q<rails>, [">= 2.3.5"])
@@ -72,7 +70,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
     s.add_dependency(%q<rcov>, [">= 0"])
-    s.add_dependency(%q<rails>, [">= 2.3.5"])
   end
 end
 


### PR DESCRIPTION
This fixes an issue with the latest bundler which does not like duplicate dependencies in gemspecs.
